### PR TITLE
Adicionar testes de integração e referências de pacotes

### DIFF
--- a/StockApp.Domain.Test/IntegrationTestscs.cs
+++ b/StockApp.Domain.Test/IntegrationTestscs.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.VisualStudio.TestPlatform.TestHost;
+using StockApp.Application.DTOs;
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StockApp.Domain.Test
+{
+    public class IntegrationTests : IClassFixture<WebApplicationFactory<Program>>
+    {
+        private readonly HttpClient _client;
+
+        public IntegrationTests(WebApplicationFactory<Program> factory)
+        {
+            _client = factory.CreateClient();
+        }
+
+        [Fact]
+        public async Task RegisterAndLogin_ValidCredentials_ReturnsToken()
+        {
+            // Arrange
+            var userRegisterDto = new UserRegisterDTO
+            {
+                Username = "testuser",
+                Password = "password",
+                Role = "User"
+            };
+
+            var userLoginDto = new UserLoginDTO
+            {
+                Username = "testuser",
+                Password = "password"
+            };
+
+            // Register
+            var registerResponse = await _client.PostAsJsonAsync("/api/user/register", userRegisterDto);
+            registerResponse.EnsureSuccessStatusCode();
+
+            // Login
+            var loginResponse = await _client.PostAsJsonAsync("/api/token/login", userLoginDto);
+            loginResponse.EnsureSuccessStatusCode();
+
+            var tokenResponse = await loginResponse.Content.ReadFromJsonAsync<TokenResponseDTO>();
+
+            // Assert
+            Assert.NotNull(tokenResponse);
+            Assert.NotNull(tokenResponse.Token);
+            Assert.True(tokenResponse.Expiration > DateTime.UtcNow);
+        }
+    }
+}

--- a/StockApp.Domain.Test/StockApp.Domain.Test.csproj
+++ b/StockApp.Domain.Test/StockApp.Domain.Test.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.25" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
@@ -22,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\StockApp.Application\StockApp.Application.csproj" />
     <ProjectReference Include="..\StockApp.Domain\StockApp.Domain.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Foi atualizado o arquivo `StockApp.Domain.Test.csproj` para incluir referências a pacotes como `Microsoft.AspNetCore.Mvc.Testing`, `Microsoft.NET.Test.Sdk`, `xunit` e `xunit.runner.visualstudio`, além de referências a projetos locais `StockApp.Application` e `StockApp.Domain`.

Um novo arquivo de teste de integração foi criado em `IntegrationTestscs.cs`, contendo a classe `IntegrationTests`. Esta classe utiliza o `WebApplicationFactory<Program>` para criar um cliente HTTP e testar a funcionalidade de registro e login de usuários, garantindo que um token seja retornado com sucesso após o registro e login com credenciais válidas.