### PR TITLE
Adicionar serviço de análise de sentimento e testes

### DIFF
--- a/StockApp.Application/Services/SentimentAnalysisService.cs
+++ b/StockApp.Application/Services/SentimentAnalysisService.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public interface ISentimentAnalysisService
+{
+    string AnalyzeSentiment(string review);
+}
+
+public class SentimentAnalysisService : ISentimentAnalysisService
+{
+    private static readonly string[] PositiveWords = { "ótimo", "excelente", "bom", "maravilhoso", "recomendo", "gostei", "perfeito", "adoro" };
+    private static readonly string[] NegativeWords = { "ruim", "péssimo", "horrível", "odiei", "terrível", "inapropriado", "detestei" };
+
+    public string AnalyzeSentiment(string review)
+    {
+        if (string.IsNullOrWhiteSpace(review))
+            return "Neutro";
+
+        var reviewLower = review.ToLower();
+
+        int positiveScore = PositiveWords.Count(word => reviewLower.Contains(word));
+        int negativeScore = NegativeWords.Count(word => reviewLower.Contains(word));
+
+        if (positiveScore > negativeScore)
+            return "Positivo";
+        if (negativeScore > positiveScore)
+            return "Negativo";
+        if (negativeScore > 0) 
+            return "Negativo";
+        return "Neutro";
+    }
+}

--- a/StockApp.Domain.Test/SentimentAnalysisServiceTests.cs
+++ b/StockApp.Domain.Test/SentimentAnalysisServiceTests.cs
@@ -1,0 +1,22 @@
+﻿using Xunit;
+
+public class SentimentAnalysisServiceTests
+{
+    [Theory]
+    [InlineData("Este produto é ótimo!", "Positivo")]
+    [InlineData("O serviço foi excelente e maravilhoso.", "Positivo")]
+    [InlineData("Produto ruim e horrível.", "Negativo")]
+    [InlineData("Não gostei, foi péssimo.", "Negativo")]
+    [InlineData("Produto comum, nada demais.", "Neutro")]
+    [InlineData("", "Neutro")]
+    [InlineData(null, "Neutro")]
+    [InlineData("Gostei e odiei ao mesmo tempo.", "Neutro")]
+    public void AnalyzeSentiment_DeveRetornarSentimentoCorreto(string review, string esperado)
+    {
+        var service = new SentimentAnalysisService();
+
+        var resultado = service.AnalyzeSentiment(review);
+
+        Assert.Equal(esperado, resultado);
+    }
+}


### PR DESCRIPTION
Implementa o `SentimentAnalysisService` com a interface `ISentimentAnalysisService`, que analisa o sentimento de revisões utilizando listas de palavras positivas e negativas. Inclui testes unitários com `Xunit` para validar o método `AnalyzeSentiment` com diferentes entradas.